### PR TITLE
Base de données dans le cloud

### DIFF
--- a/AstroLogement/.env
+++ b/AstroLogement/.env
@@ -24,7 +24,7 @@ APP_SECRET=
 # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
 #
 # DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
-DATABASE_URL="mysql://root:SpaceBnB@127.0.0.1:3307/AstroLogement?serverVersion=8.0.32&charset=utf8mb4"
+DATABASE_URL=${DATABASE_URL}
 # DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=10.11.2-MariaDB&charset=utf8mb4"
 # DATABASE_URL="postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=16&charset=utf8"
 ###< doctrine/doctrine-bundle ###


### PR DESCRIPTION
Il faut créer le fichier de .env.local en local pour relier la base de données dans le cloud